### PR TITLE
docs: add MIT license and update README with latest tech stack versions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,41 @@
+MIT License
+
+Copyright (c) 2025 Claude Next.js DevContainer Template
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## 日本語版 (Japanese Version)
+
+MITライセンス
+
+Copyright (c) 2025 Claude Next.js DevContainer Template
+
+本ソフトウェアおよび関連文書ファイル（以下「ソフトウェア」）の複製を取得するすべての人に対し、
+ソフトウェアを制限なく扱うことを無償で許可します。これには、ソフトウェアの使用、複製、変更、結合、
+出版、配布、サブライセンス、および/またはソフトウェアの複製を販売する権利、およびソフトウェアが
+提供される人に同じことを許可する権利を含みます。
+
+上記の著作権表示およびこの許可表示は、ソフトウェアのすべての複製または重要な部分に含まれます。
+
+ソフトウェアは「現状のまま」提供され、明示または黙示を問わず、商品性、特定目的への適合性、
+および非侵害性についての保証を含みません。いかなる場合においても、作者または著作権者は、
+契約、不法行為、またはその他の方法で生じる、ソフトウェアまたはソフトウェアの使用またはその他の
+取引に関連する、請求、損害、またはその他の責任について責任を負いません。 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,19 @@ A Next.js starter template with a fully configured DevContainer environment opti
 
 ## Tech Stack (技術スタック)
 
-Tech stack intended for building with this template:
+**As of July 2, 2025 (2025年7月2日現在)**
 
-このテンプレートを使用して構築することを想定している技術スタック：
+Tech stack intended for building with this template. We prioritize using the latest stable versions of all technologies:
+
+このテンプレートを使用して構築することを想定している技術スタック。全ての技術において最新の安定版の使用を優先します：
 
 - **Frontend**
-  - Next.js 14+ (React framework with App Router)
-  - TypeScript for type safety
-  - Tailwind CSS for styling
-  - shadcn/ui component library
+  - Next.js 15.0.0+ (React framework with App Router)
+  - React 18.3.0+ (Latest stable version)
+  - TypeScript 5.4.0+ for type safety
+  - Tailwind CSS 3.4.0+ for styling
+  - shadcn/ui component library (Latest stable)
+  - Radix UI primitives for accessible components
 - **Backend**
   - Next.js API Routes
   - Supabase integration ready
@@ -29,16 +33,24 @@ Tech stack intended for building with this template:
 git clone <your-repo-url> my-nextjs-app
 cd my-nextjs-app
 
+# Clean up any existing volumes (prevents permission issues)
+docker compose down
+docker volume prune -f
+
 # Start development environment
 docker compose up -d
 
 # Enter the container
 docker compose exec nextjs-dev zsh
 
-# After setting up your Next.js application:
-# npm install
-# npm run dev
+# Install dependencies (should work without permission errors now)
+npm install
+
+# Start development server
+npm run dev
 ```
+
+**Important**: Always run `docker compose down` and `docker volume prune -f` before starting fresh to prevent permission issues.
 
 ### Using Claude Code
 


### PR DESCRIPTION
- Add MIT license file with English and Japanese versions
- Update tech stack to latest stable versions (Next.js 15.0.0+, React 18.3.0+, TypeScript 5.4.0+)
- Improve setup instructions with volume cleanup steps to prevent permission issues
- Add timestamp for tech stack currency (July 2, 2025)

## 日本語

MITライセンスの追加とREADMEの最新技術スタック版への更新

- 英語版・日本語版のMITライセンスファイルを追加
- 技術スタックを最新安定版に更新（Next.js 15.0.0+、React 18.3.0+、TypeScript 5.4.0+）
- 権限問題を防ぐためのボリュームクリーンアップ手順を含むセットアップ説明の改善
- 技術スタックの時点性を示すタイムスタンプを追加（2025年7月2日）

🤖 Generated with [Claude Code](https://claude.ai/code)