### PR TITLE
fix: remove node_modules cache volume mount from compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -16,8 +16,6 @@ services:
       - gh-config:/home/node/.config/gh
       # SSH設定のマウント（ホストマシンから）
       - ~/.ssh:/home/node/.ssh:ro
-      # node_modulesキャッシュ（nodeユーザー権限で作成）
-      - node_modules_cache:/workspace/node_modules
     working_dir: /workspace
     environment:
       - NODE_OPTIONS=--max-old-space-size=4096


### PR DESCRIPTION
- Remove node_modules cache volume mount that was causing permission errors
- Eliminate container startup issues related to volume permissions
- Allow npm install to create node_modules as regular directory

- node_modulesキャッシュボリュームマウントを削除し権限エラーを解決
- ボリューム権限に関連するコンテナ起動問題を解消
- npm installが通常のディレクトリとしてnode_modulesを作成することを許可

🤖 Generated with [Claude Code](https://claude.ai/code)